### PR TITLE
Experimental - Add percentage count

### DIFF
--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -215,6 +215,7 @@ window.api = {
           name: author,
           repoId: repoName,
           variance: commits.authorContributionVariance[author],
+          percentage: commits.authorContributionPercentage[author],
           displayName: commits.authorDisplayNameMap[author],
           dailyCommits: commits.authorDailyContributionsMap[author],
           fileTypeContribution: commits.authorFileTypeContributionMap[author],

--- a/frontend/src/summary_charts.pug
+++ b/frontend/src/summary_charts.pug
@@ -133,6 +133,9 @@
         .summary-chart__title--percentile(
           v-if="filterGroupSelection === 'groupByNone'"
         ) {{ getPercentile(j) }} %
+        .summary-chart__title--percentile(
+          v-if="filterGroupSelection === 'groupByRepos'"
+        ) {{ user.percentage }} %
 
       .summary-chart__ramp(
         v-on:click="openTabZoomSubrange(user, $event, isGroupMerged(getGroupName(repo)))"

--- a/src/main/java/reposense/commits/model/CommitContributionSummary.java
+++ b/src/main/java/reposense/commits/model/CommitContributionSummary.java
@@ -12,14 +12,17 @@ public class CommitContributionSummary {
     private final Map<Author, List<AuthorDailyContribution>> authorDailyContributionsMap;
     private final Map<Author, Float> authorContributionVariance;
     private final Map<Author, String> authorDisplayNameMap;
+    private final Map<Author, Float> authorContributionPercentage;
 
     public CommitContributionSummary(
             Map<Author, String> authorDisplayNameMap,
             Map<Author, List<AuthorDailyContribution>> authorDailyContributionsMap,
-            Map<Author, Float> authorContributionVariance) {
+            Map<Author, Float> authorContributionVariance,
+            Map<Author, Float> authorContributionPercentage) {
         this.authorDisplayNameMap = authorDisplayNameMap;
         this.authorDailyContributionsMap = authorDailyContributionsMap;
         this.authorContributionVariance = authorContributionVariance;
+        this.authorContributionPercentage = authorContributionPercentage;
     }
 
     public Map<Author, String> getAuthorDisplayNameMap() {
@@ -32,5 +35,9 @@ public class CommitContributionSummary {
 
     public Map<Author, Float> getAuthorContributionVariance() {
         return authorContributionVariance;
+    }
+
+    public Map<Author, Float> getAuthorContributionPercentage() {
+        return authorContributionPercentage;
     }
 }

--- a/src/main/java/reposense/report/CommitReportJson.java
+++ b/src/main/java/reposense/report/CommitReportJson.java
@@ -20,6 +20,7 @@ public class CommitReportJson {
     private final Map<Author, LinkedHashMap<FileType, Integer>> authorFileTypeContributionMap;
     private final Map<Author, Float> authorContributionVariance;
     private final Map<Author, String> authorDisplayNameMap;
+    private final Map<Author, Float> authorContributionPercentage;
 
     /**
      * Constructor to construct an empty commit report with the author's display name as {@code displayName}.
@@ -38,6 +39,9 @@ public class CommitReportJson {
 
         authorDisplayNameMap = new HashMap<>();
         authorDisplayNameMap.put(emptyAuthor, displayName);
+
+        authorContributionPercentage = new HashMap<>();
+        authorContributionPercentage.put(emptyAuthor, (float) 0.0);
     }
 
     public CommitReportJson(CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
@@ -45,5 +49,6 @@ public class CommitReportJson {
         authorFileTypeContributionMap = authorshipSummary.getAuthorFileTypeContributionMap();
         authorContributionVariance = commitSummary.getAuthorContributionVariance();
         authorDisplayNameMap = commitSummary.getAuthorDisplayNameMap();
+        authorContributionPercentage = commitSummary.getAuthorContributionPercentage();
     }
 }


### PR DESCRIPTION
The percentage count for individual authors is implemented for reports that are grouped by repos:
![image](https://user-images.githubusercontent.com/69678785/127774727-db92f433-b170-48ed-83aa-5eccbce90308.png)

Based on the image above, the implemented percentage is flushed to the right of each author's chart (circled green) and is calculated by dividing each author's line count (circled blue) by the line count for the repo (circled red) and multiplying by 100%. This is provided that the line count for the repo is a positive number.

For a repo with line count of 0, each author's percentage is automatically set to 0%.

Commit message:

```
While a generated report shows the total number of lines 
for each branch as well as lines from each author, a percentage display 
would be more helpful for analysing contributions during team projects.

Let's calculate the percentage of lines in the commit history belonging 
to each author. This makes visualisation of how much each author has 
contributed easier and saves the effort needed to manually calculate 
based on the number of lines.
```

